### PR TITLE
Android ビルドで exportFormat に応じて buildAppBundle を設定

### DIFF
--- a/Assets/VeUnityBuild/Editor/Domains/Tasks/AndroidBuildTask.cs
+++ b/Assets/VeUnityBuild/Editor/Domains/Tasks/AndroidBuildTask.cs
@@ -24,6 +24,10 @@ namespace VeUnityBuild.Editor.Domains.Tasks
                 _ => throw new ArgumentException($"Invalid build mode: {_buildParameter.BuildMode}")
             };
 
+            // The exportFormat only changes the output file extension. EditorUserBuildSettings.buildAppBundle
+            // must also be set, otherwise Unity produces an APK even when the file is named ".aab".
+            EditorUserBuildSettings.buildAppBundle = _buildConfig.exportFormat == AndroidExportFormat.Aab;
+
             try
             {
                 BuildPipeline.BuildPlayer(


### PR DESCRIPTION
## 概要

`AndroidBuildTask` は出力ファイルの拡張子しか切り替えておらず、`EditorUserBuildSettings.buildAppBundle` を設定していませんでした。

このため `exportFormat` を `Aab` にしても、`buildAppBundle` が `false` のままだと **中身が APK のファイルが `.aab` という名前で出力される** という問題がありました（`buildAppBundle` は `Library/` 配下に保存され非バージョン管理のため、利用側のローカル/CI 状態に依存していました）。

## 変更内容

`BuildPipeline.BuildPlayer` 呼び出し前に、`exportFormat` に応じて `EditorUserBuildSettings.buildAppBundle` を設定します。

- `exportFormat == Aab` → `buildAppBundle = true`
- `exportFormat == Apk` → `buildAppBundle = false`

これにより、設定値どおりの成果物（実体も AAB / APK）が出力されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)