### PR TITLE
Android 署名パスワードを CLI オプションで受け取れるようにする

### DIFF
--- a/Assets/VeUnityBuild/Editor/Constants.cs
+++ b/Assets/VeUnityBuild/Editor/Constants.cs
@@ -10,10 +10,11 @@ namespace VeUnityBuild.Editor
         public const string BuildModeOptionKey = "-buildMode";
         public const string BuildConfigOptionKey = "-buildConfig";
 
-        // Unity's -androidKeystorePass / -androidKeyaliasPass are only honored by the Build
-        // Settings flow, not by BuildPipeline.BuildPlayer invoked via -executeMethod. We reuse
-        // the same option names and apply them to PlayerSettings ourselves; Unity simply ignores
-        // them for this build path, so there is no conflict.
+        // -androidKeystorePass / -androidKeyaliasPass are not part of Unity's official
+        // command-line interface; they are a de-facto naming convention used by CI tooling.
+        // VeUnityBuild defines its own options under the same conventional names and applies
+        // them via the PlayerSettings.Android API, because Unity does not process these
+        // arguments for BuildPipeline.BuildPlayer invoked via -executeMethod.
         public const string AndroidKeystorePassOptionKey = "-androidKeystorePass";
         public const string AndroidKeyaliasPassOptionKey = "-androidKeyaliasPass";
 

--- a/Assets/VeUnityBuild/Editor/Constants.cs
+++ b/Assets/VeUnityBuild/Editor/Constants.cs
@@ -9,6 +9,13 @@ namespace VeUnityBuild.Editor
 
         public const string BuildModeOptionKey = "-buildMode";
         public const string BuildConfigOptionKey = "-buildConfig";
+
+        // Unity's built-in -androidKeystorePass / -androidKeyaliasPass are only honored by the
+        // Build Settings flow, not by BuildPipeline.BuildPlayer invoked via -executeMethod.
+        // VeUnityBuild parses its own dedicated options and applies them to PlayerSettings.
+        public const string AndroidKeystorePassOptionKey = "-veAndroidKeystorePass";
+        public const string AndroidKeyaliasPassOptionKey = "-veAndroidKeyaliasPass";
+
         public const int Version = 1;
     }
 }

--- a/Assets/VeUnityBuild/Editor/Constants.cs
+++ b/Assets/VeUnityBuild/Editor/Constants.cs
@@ -10,11 +10,12 @@ namespace VeUnityBuild.Editor
         public const string BuildModeOptionKey = "-buildMode";
         public const string BuildConfigOptionKey = "-buildConfig";
 
-        // Unity's built-in -androidKeystorePass / -androidKeyaliasPass are only honored by the
-        // Build Settings flow, not by BuildPipeline.BuildPlayer invoked via -executeMethod.
-        // VeUnityBuild parses its own dedicated options and applies them to PlayerSettings.
-        public const string AndroidKeystorePassOptionKey = "-veAndroidKeystorePass";
-        public const string AndroidKeyaliasPassOptionKey = "-veAndroidKeyaliasPass";
+        // Unity's -androidKeystorePass / -androidKeyaliasPass are only honored by the Build
+        // Settings flow, not by BuildPipeline.BuildPlayer invoked via -executeMethod. We reuse
+        // the same option names and apply them to PlayerSettings ourselves; Unity simply ignores
+        // them for this build path, so there is no conflict.
+        public const string AndroidKeystorePassOptionKey = "-androidKeystorePass";
+        public const string AndroidKeyaliasPassOptionKey = "-androidKeyaliasPass";
 
         public const int Version = 1;
     }

--- a/Assets/VeUnityBuild/Editor/Domains/BuildParameter.cs
+++ b/Assets/VeUnityBuild/Editor/Domains/BuildParameter.cs
@@ -5,5 +5,7 @@ namespace VeUnityBuild.Editor.Domains
     public class BuildParameter : IContextObject
     {
         public string BuildMode { get; set; }
+        public string AndroidKeystorePass { get; set; }
+        public string AndroidKeyaliasPass { get; set; }
     }
 }

--- a/Assets/VeUnityBuild/Editor/Domains/Tasks/AndroidBuildTask.cs
+++ b/Assets/VeUnityBuild/Editor/Domains/Tasks/AndroidBuildTask.cs
@@ -28,8 +28,8 @@ namespace VeUnityBuild.Editor.Domains.Tasks
             // must also be set, otherwise Unity produces an APK even when the file is named ".aab".
             EditorUserBuildSettings.buildAppBundle = _buildConfig.exportFormat == AndroidExportFormat.Aab;
 
-            // Unity's -androidKeystorePass / -androidKeyaliasPass are ignored when building via
-            // BuildPipeline.BuildPlayer, so apply VeUnityBuild's own options to PlayerSettings here.
+            // Unity ignores -androidKeystorePass / -androidKeyaliasPass when building via
+            // BuildPipeline.BuildPlayer, so apply the values to PlayerSettings ourselves.
             if (!string.IsNullOrEmpty(_buildParameter.AndroidKeystorePass))
             {
                 PlayerSettings.Android.keystorePass = _buildParameter.AndroidKeystorePass;

--- a/Assets/VeUnityBuild/Editor/Domains/Tasks/AndroidBuildTask.cs
+++ b/Assets/VeUnityBuild/Editor/Domains/Tasks/AndroidBuildTask.cs
@@ -28,6 +28,18 @@ namespace VeUnityBuild.Editor.Domains.Tasks
             // must also be set, otherwise Unity produces an APK even when the file is named ".aab".
             EditorUserBuildSettings.buildAppBundle = _buildConfig.exportFormat == AndroidExportFormat.Aab;
 
+            // Unity's -androidKeystorePass / -androidKeyaliasPass are ignored when building via
+            // BuildPipeline.BuildPlayer, so apply VeUnityBuild's own options to PlayerSettings here.
+            if (!string.IsNullOrEmpty(_buildParameter.AndroidKeystorePass))
+            {
+                PlayerSettings.Android.keystorePass = _buildParameter.AndroidKeystorePass;
+            }
+
+            if (!string.IsNullOrEmpty(_buildParameter.AndroidKeyaliasPass))
+            {
+                PlayerSettings.Android.keyaliasPass = _buildParameter.AndroidKeyaliasPass;
+            }
+
             try
             {
                 BuildPipeline.BuildPlayer(

--- a/Assets/VeUnityBuild/Editor/Domains/Tasks/AndroidBuildTask.cs
+++ b/Assets/VeUnityBuild/Editor/Domains/Tasks/AndroidBuildTask.cs
@@ -28,8 +28,8 @@ namespace VeUnityBuild.Editor.Domains.Tasks
             // must also be set, otherwise Unity produces an APK even when the file is named ".aab".
             EditorUserBuildSettings.buildAppBundle = _buildConfig.exportFormat == AndroidExportFormat.Aab;
 
-            // Unity ignores -androidKeystorePass / -androidKeyaliasPass when building via
-            // BuildPipeline.BuildPlayer, so apply the values to PlayerSettings ourselves.
+            // Keystore / keyalias passwords cannot be supplied to BuildPipeline.BuildPlayer
+            // through command-line arguments, so apply them via the PlayerSettings.Android API.
             if (!string.IsNullOrEmpty(_buildParameter.AndroidKeystorePass))
             {
                 PlayerSettings.Android.keystorePass = _buildParameter.AndroidKeystorePass;

--- a/Assets/VeUnityBuild/Editor/Infrastructures/ContextObjectRepository.cs
+++ b/Assets/VeUnityBuild/Editor/Infrastructures/ContextObjectRepository.cs
@@ -24,7 +24,12 @@ namespace VeUnityBuild.Editor.Infrastructures
             }
 
             var buildMode = getCommandLineArgsUseCase.GetValue(Constant.BuildModeOptionKey);
-            var parameterContext = new BuildParameter { BuildMode = buildMode };
+            var parameterContext = new BuildParameter
+            {
+                BuildMode = buildMode,
+                AndroidKeystorePass = getCommandLineArgsUseCase.GetValue(Constant.AndroidKeystorePassOptionKey),
+                AndroidKeyaliasPass = getCommandLineArgsUseCase.GetValue(Constant.AndroidKeyaliasPassOptionKey),
+            };
             return new IContextObject[] { buildConfig, parameterContext };
         }
     }


### PR DESCRIPTION
## 概要

custom keystore を使う Android ビルドで、keystore / keyalias パスワードを `BuildPipeline.BuildPlayer`（`-executeMethod` 経由）に渡す手段がなく、`UnityException: Can not sign the application / Unable to sign the application; please provide passwords!` で失敗していました。

補足: `-androidKeystorePass` / `-androidKeyaliasPass` は Unity 公式のコマンドラインインターフェースには存在しません（[公式 CLI マニュアル](https://docs.unity3d.com/6000.3/Documentation/Manual/CommandLineArguments.html)に記載なし）。CI ツール（game-ci/unity-builder 等）で広く使われている慣習名にすぎず、`-executeMethod` + `BuildPipeline.BuildPlayer` のフローでは適用されません。Unity が公式に提供する手段は scripting API の [`PlayerSettings.Android.keystorePass` / `keyaliasPass`](https://docs.unity3d.com/ScriptReference/PlayerSettings.Android-keystorePass.html) です。

## 変更内容

VeUnityBuild が CLI から keystore / keyalias パスワードを受け取り、`AndroidBuildTask` で `BuildPipeline.BuildPlayer` 前に公式 API の `PlayerSettings.Android` へ適用します。

- `Constant`: `-androidKeystorePass` / `-androidKeyaliasPass` を追加（慣習名に合わせた VeUnityBuild 独自オプション）
- `BuildParameter`: `AndroidKeystorePass` / `AndroidKeyaliasPass` を追加
- `ContextObjectRepository`: CLI からこれらを読み取り `BuildParameter` に格納
- `AndroidBuildTask`: 値が指定されている場合のみ `PlayerSettings.Android.keystorePass` / `keyaliasPass` を設定

オプション名は CI で一般的な慣習名に合わせています。Unity はこの引数を `-executeMethod` ビルドで処理しないため衝突しません。keystore 名 / alias 名 / `useCustomKeystore` は ProjectSettings の設定をそのまま使います（パスワードのみ注入）。

## 使い方

```
-androidKeystorePass "$KEYSTORE_PASS" -androidKeyaliasPass "$KEYALIAS_PASS"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)